### PR TITLE
Add missing steps to readme and runme.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /tools
 /V2XSW
 /overlay
+imx-scfw-porting-kit-*

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A docker image providing a consistent build environment can be used as below:
    # optional with an apt proxy, e.g. apt-cacher-ng
    # docker build --build-arg APTPROXY=http://127.0.0.1:3142 -t imx8mm_build docker
    ```
-2. invoke build script in working directory
+2. Download "SCFW Porting Kit​ 1.13.0" for Linux 5.15.32_2.0.0 from [NXP IMXLINUX](https://www.nxp.com/design/software/embedded-software/i-mx-software/embedded-linux-for-i-mx-applications-processors:IMXLINUX) and place it in the root of this repository (first time only)
+3. invoke build script in working directory
    ```
    docker run -i -t -v "$PWD":/work imx8dxl_build -u $(id -u) -g $(id -g)
    ```

--- a/runme.sh
+++ b/runme.sh
@@ -195,6 +195,7 @@ cp -v u-boot.bin "${ROOTDIR}/build/mkimage/iMX8DXL/"
 # Assemble bootable image
 cd "${ROOTDIR}/build/mkimage"
 make SOC=iMX8DXL REV=${SOC_REVISION^^} flash
+mkdir -p ${ROOTDIR}/images
 cp -v "${ROOTDIR}/build/mkimage/iMX8DXL/flash.bin" "${ROOTDIR}/images/uboot.bin"
 
 echo "Finished compiling bootloader image."
@@ -233,6 +234,7 @@ if [[ -d ${ROOTDIR}/V2XSW ]]; then
 fi
 
 # Generate a Debian rootfs
+mkdir -p "${ROOTDIR}/build/debian"
 cd "${ROOTDIR}/build/debian"
 if [ ! -f rootfs.e2.orig ] || [[ ${ROOTDIR}/${BASH_SOURCE[0]} -nt rootfs.e2.orig ]]; then
 	rm -f rootfs.e2.orig


### PR DESCRIPTION
The runme.sh script will fail, if the SCFW porting kit does not exist. So this PR adds that to the setup steps in the readme.

And the script tries to copy files to a directory which doesn't exist and later on tries to move to a directory, which doesn't exist in a clean setup. So two `mkdir -p` calls were added to the script.