### PR TITLE
V2X: Cross-compile and install full modem software stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,15 @@ After flashing the root filesystem is smaller than the eMMC. To utilize all spac
 Note that this step requires access to the partially proprietary software-stack by NXP.
 Customers can request access to a standalone zip file with all required pieces, based on NXPs v0.13 release, along with patches for initial support of our SoM.
 
+If the right source code is present in the `V2XSW` directory, all required kernel modules and software will be compiled and added to the image.
+The modem driver will be started automatically by a `saf-llc.service` systemd unit.
+
 ### Compile Kernel Modules
 
 To compile the kernel drivers as part of executing `runme.sh`, the zip file must be unpacked inside `imx8dxl_build` to create the `V2XSW` folder.
 The build script will pick up sources from there and compile both `saf_sdio.ko` and `cw-llc.ko` automatically, and include them in the disk image.
 
-Install them by flashing the new disk image, or copying individually (`images/linux/usr/lib/modules/*/kernel/v2x/{saf_sdio.ko,cw-llc.ko}`).
+Install them by flashing the new disk image, or copying individually (`images/linux/usr/lib/modules/*/extra/{saf_sdio.ko,cw-llc.ko}`).
 
 ### Compile Application(s)
 

--- a/runme.sh
+++ b/runme.sh
@@ -3,7 +3,7 @@
 ### Options
 : ${CROSS_COMPILE:=aarch64-linux-gnu-}
 : ${SOC_REVISION:=A0}
-: ${IMAGE_SIZE_MiB:=1000}
+: ${IMAGE_SIZE_MiB:=1500}
 
 ### Versions
 ATF_GIT_URI=https://source.codeaurora.org/external/imx/imx-atf
@@ -245,7 +245,7 @@ if [ ! -f rootfs.e2.orig ] || [[ ${ROOTDIR}/${BASH_SOURCE[0]} -nt rootfs.e2.orig
 	fakeroot debootstrap --variant=minbase \
 		--arch=arm64 --components=main,contrib,non-free \
 		--foreign \
-		--include=apt-transport-https,bluez,busybox,ca-certificates,can-utils,command-not-found,curl,e2fsprogs,ethtool,fdisk,gpiod,gpsd,gpsd-tools,haveged,i2c-tools,ifupdown,iputils-ping,isc-dhcp-client,iw,initramfs-tools,locales,nano,net-tools,ntpdate,openssh-server,psmisc,python3-gps,python3-serial,rfkill,sudo,systemd-sysv,systemd-timesyncd,tio,usbutils,wget,wpasupplicant \
+		--include=apt-transport-https,bluez,busybox,ca-certificates,can-utils,command-not-found,curl,e2fsprogs,ethtool,fdisk,gpiod,gpsd,gpsd-tools,gpsd-clients,haveged,i2c-tools,ifupdown,iputils-ping,isc-dhcp-client,iw,initramfs-tools,locales,nano,net-tools,ntpdate,openssh-server,psmisc,python3-gps,python3-serial,rfkill,sudo,systemd-sysv,systemd-timesyncd,tio,usbutils,wget,wpasupplicant \
 		bullseye \
 		stage1 \
 		https://deb.debian.org/debian


### PR DESCRIPTION
As far as my research got, out-of-tree kernel modules should be in the `extra` directory, so I changed the install location.
All other tools from the LLC remote will also be cross-compiled and installed. Unfortunately I couldn't figure out how `e2cp` can preserve the symlinks (just needed for the compiled libraries as they link `.so.3.4` to `.so.3.4.3`).

Please note, that I added some more patches to the LLC remote source to make this work properly.

This PR also installs the `gpsd-clients` package as `gpspipe` is needed by a certain V2X stack provider.