### PR TITLE
SJA1110 Patches: Install phytool and disable power-down

### DIFF
--- a/overlay/etc/systemd/network/lan1-dhcp.network
+++ b/overlay/etc/systemd/network/lan1-dhcp.network
@@ -1,0 +1,7 @@
+[Match]
+Name=lan1
+
+[Network]
+LLMNR=no
+MulticastDNS=yes
+DHCP=ipv4

--- a/overlay/etc/systemd/system/sja1110-patch.service
+++ b/overlay/etc/systemd/system/sja1110-patch.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=SJA1110 disable power-down mode
+Before=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/phytool write lan1/1/0x18 0x60
+
+[Install]
+WantedBy=multi-user.target

--- a/runme.sh
+++ b/runme.sh
@@ -19,12 +19,14 @@ SCFW_FILE_URI="https://www.nxp.com/webapp/Download?colCode=L5.15.32_2.0.0_SCFWKI
 SCFW_RELEASE=1.13.0
 LINUX_GIT_URI=https://source.codeaurora.org/external/imx/linux-imx
 LINUX_RELEASE=lf-5.15.32-2.0.0
+PHYTOOL_GIT_URI=https://github.com/wkz/phytool.git
+PHYTOOL_RELEASE=b8237fc69000d205ca0c59efe9462d3115077f6c # latest master as of 2022-11-01
 
 ###
 
 ROOTDIR=`pwd`
 
-COMPONENTS="atf uboot mkimage seco scfw linux"
+COMPONENTS="atf uboot mkimage seco scfw linux phytool"
 mkdir -p build
 dlfailed=0
 for i in $COMPONENTS; do
@@ -221,6 +223,12 @@ label linux
 	append root=/dev/mmcblk0p1 ro rootwait
 EOF
 
+# Build phytool
+cd "${ROOTDIR}/build/phytool"
+make CC="${CROSS_COMPILE}gcc" all
+install -d "${ROOTDIR}/images/linux/usr/local/sbin/"
+install -c phytool "${ROOTDIR}/images/linux/usr/local/sbin/"
+
 # Build V2X kernel drivers
 if [[ -d ${ROOTDIR}/V2XSW ]]; then
 	cd "${ROOTDIR}/V2XSW/src/saf-sdio"
@@ -245,7 +253,7 @@ if [ ! -f rootfs.e2.orig ] || [[ ${ROOTDIR}/${BASH_SOURCE[0]} -nt rootfs.e2.orig
 	fakeroot debootstrap --variant=minbase \
 		--arch=arm64 --components=main,contrib,non-free \
 		--foreign \
-		--include=apt-transport-https,bluez,busybox,ca-certificates,can-utils,command-not-found,curl,e2fsprogs,ethtool,fdisk,gpiod,gpsd,gpsd-tools,haveged,i2c-tools,ifupdown,iputils-ping,isc-dhcp-client,iw,initramfs-tools,locales,nano,net-tools,ntpdate,openssh-server,psmisc,python3-gps,python3-serial,rfkill,sudo,systemd-sysv,systemd-timesyncd,tio,usbutils,wget,wpasupplicant \
+		--include=apt-transport-https,bluez,busybox,ca-certificates,can-utils,command-not-found,curl,e2fsprogs,ethtool,fdisk,gpiod,gpsd,gpsd-tools,haveged,i2c-tools,ifupdown,iputils-ping,isc-dhcp-client,iw,libnss-resolve,initramfs-tools,locales,nano,net-tools,ntpdate,openssh-server,psmisc,python3-gps,python3-serial,rfkill,sudo,systemd-sysv,systemd-timesyncd,tio,usbutils,wget,wpasupplicant \
 		bullseye \
 		stage1 \
 		https://deb.debian.org/debian
@@ -273,6 +281,14 @@ update-command-not-found
 
 # populate fstab
 printf "/dev/root / ext4 defaults 0 1\\n" > /etc/fstab
+
+# start sja1110-patch on boot
+ln -s /etc/systemd/system/sja1110-patch.service /etc/systemd/system/multi-user.target.wants/sja1110-patch.service
+
+# enable systemd-networkd and re-configure DNS
+systemctl enable systemd-networkd
+systemctl enable systemd-resolved
+ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 
 # delete self
 rm -f /stage2.sh


### PR DESCRIPTION
The readme describes, that the power-down mode of the SJA1110 network switch needs to be disabled to make it work properly. A special tool needs to be compiled to issue the corresponding command to the switch.

This PR takes care of cross-compiling the `phytool` and installs a systemd unit to issue the command on boot. We need to enable the unit by setting the symlink manually as the service file will only be copied to the image in a later stage of the `runme.sh` script.

The provided systemd-networkd configuration does not delay the boot if no network cable is plugged in. It will configure an IPv4 and IPv6 address as soon as a carrier is detected and de-configure the interface on a lost carrier. So everything works as expected. Configuration with ifupdown would have required more patches or additional packages to de-configure the interface on an unplugged cable.