### PR TITLE
debian: configure lan1 with DHCP using systemd-networkd

### DIFF
--- a/overlay/etc/network/interfaces.d/lan1
+++ b/overlay/etc/network/interfaces.d/lan1
@@ -1,3 +1,0 @@
-allow-hotplug lan1
-iface lan1 inet dhcp
-iface lan1 inet6 auto

--- a/overlay/etc/systemd/network/lan1-dhcp.network
+++ b/overlay/etc/systemd/network/lan1-dhcp.network
@@ -1,0 +1,7 @@
+[Match]
+Name=lan1
+
+[Network]
+LLMNR=no
+MulticastDNS=yes
+DHCP=ipv4

--- a/runme.sh
+++ b/runme.sh
@@ -279,7 +279,7 @@ if [ ! -f rootfs.e2.orig ] || [[ ${ROOTDIR}/${BASH_SOURCE[0]} -nt rootfs.e2.orig
 	fakeroot debootstrap --variant=minbase \
 		--arch=arm64 --components=main,contrib,non-free \
 		--foreign \
-		--include=apt-transport-https,bluez,busybox,ca-certificates,can-utils,command-not-found,curl,e2fsprogs,ethtool,fdisk,gpiod,gpsd,gpsd-tools,haveged,i2c-tools,ifupdown,iputils-ping,isc-dhcp-client,iw,initramfs-tools,libpcap0.8,locales,nano,net-tools,ntpdate,openssh-server,psmisc,python3-gps,python3-serial,rfkill,sudo,systemd-sysv,systemd-timesyncd,tio,usbutils,wget,wpasupplicant,xterm \
+		--include=apt-transport-https,bluez,busybox,ca-certificates,can-utils,command-not-found,curl,e2fsprogs,ethtool,fdisk,gpiod,gpsd,gpsd-tools,haveged,i2c-tools,ifupdown,iputils-ping,isc-dhcp-client,iw,libnss-resolve,initramfs-tools,libpcap0.8,locales,nano,net-tools,ntpdate,openssh-server,psmisc,python3-gps,python3-serial,rfkill,sudo,systemd-sysv,systemd-timesyncd,tio,usbutils,wget,wpasupplicant,xterm \
 		bullseye \
 		stage1 \
 		https://deb.debian.org/debian
@@ -307,6 +307,11 @@ update-command-not-found
 
 # populate fstab
 printf "/dev/root / ext4 defaults 0 1\\n" > /etc/fstab
+
+# enable systemd-networkd and re-configure DNS
+systemctl enable systemd-networkd
+systemctl enable systemd-resolved
+ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 
 # delete self
 rm -f /stage2.sh


### PR DESCRIPTION
The current images uses ifupdown to configure the network interfaces. This will not detect when the cable is unplugged though and therefore leave the system with routes, which aren't working properly. If a cable is re-connected (to a different network), no DHCP request is issued again, which might result in an invalid IP configuration. The third issue is, that "allow-hotplug" will only setup the interface, if a cable was plugged in at boot and not afterwards.
All of those points result in a system, which behaves in an unintuitive or even unexpected way.

This PR uses systemd-networkd for interface configuration instead as it's already installed (but not activated by default). With this network manager, cable plug events are properly handled as soon as the switch driver changes the link state.

When this PR is not approved, please fix the mentioned issues with a better configuration of ifupdown.