### PR TITLE
SAF5400: Cross-compile and install all required libraries and CLI tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 /build
 /images
 /tools
-/V2XSW
 /overlay
-imx-scfw-porting-kit-*
+
+# SAF5400 source files
+llc_RFP*.tgz
+saf-sdio_RFP*.tgz
+v2x_saf_boot_RFP*.tgz
+firmware_RFP*.tgz

--- a/README.md
+++ b/README.md
@@ -305,7 +305,9 @@ After flashing the root filesystem is smaller than the eMMC. To utilize all spac
 ## Initialise Roadlink SAF5400 Modem
 
 Note that this step requires access to the partially proprietary software-stack by NXP.
-Customers can request access to a standalone zip file with all required pieces, based on NXPs v0.13 release, along with patches for initial support of our SoM.
+Customers can request access to a standalone zip file with all required pieces, based on NXPs v0.15 release.
+
+The modem driver will be started automatically by a `saf-llc.service` systemd unit.
 
 ### Compile Kernel Modules
 

--- a/overlay/etc/systemd/system/saf-llc.service
+++ b/overlay/etc/systemd/system/saf-llc.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SAF5400 Driver (SDIO)
+# network.target was too early in the boot process
+After=getty.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/saf5400-start-sdio
+ExecStop=/usr/sbin/saf5400-stop
+
+[Install]
+WantedBy=default.target

--- a/overlay/usr/sbin/saf5400-start-sdio
+++ b/overlay/usr/sbin/saf5400-start-sdio
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# check if cw_llc is loaded
+lsmod | grep cw_llc > /dev/null 2>&1
+if [ "$?" != "0" ] ; then
+    rmmod saf_sdio 2>/dev/null || true
+
+    if [ ! -e /sys/class/gpio/gpio41 ]; then
+      echo 41 > /sys/class/gpio/export
+      echo out > /sys/class/gpio/gpio41/direction
+    fi
+    if [ ! -e /sys/class/gpio/gpio42 ]; then
+      echo 42 > /sys/class/gpio/export
+      echo out > /sys/class/gpio/gpio42/direction
+    fi
+
+    # set boot-mode to sdio
+    echo 1 > /sys/class/gpio/gpio41/value
+
+    # reset
+    echo 1 > /sys/class/gpio/gpio42/value
+    echo 5b020000.mmc > /sys/bus/platform/drivers/sdhci-esdhc-imx/unbind
+    echo 0 > /sys/class/gpio/gpio42/value
+    sleep 1
+    echo 1 > /sys/class/gpio/gpio42/value
+    echo in > /sys/class/gpio/gpio41/direction
+    echo 5b020000.mmc > /sys/bus/platform/drivers/sdhci-esdhc-imx/bind
+    sleep 1
+    rmmod cw-llc
+
+    # load firmware
+    modprobe saf_sdio
+    sleep 1
+    v2x_saf_boot -W 1 -D SDIO -l /lib/firmware/SAF5X00_SBL.bin
+    v2x_saf_boot -W 1 -D SDIO -L /lib/firmware/SAF5X00_SDR_SDIO.bin
+    rmmod saf_sdio
+
+    # start llc driver
+    rmmod saf_sdio
+    modprobe cw-llc TransferMode=2
+    echo "1" > /proc/sys/net/ipv6/conf/cw-llc0/disable_ipv6
+    ip link set cw-llc0 up
+
+    # initial channel config
+    llc chconfig -s -w CCH -c 176 -a 3 -p 0 -f $(cat /sys/class/net/cw-llc0/address)
+
+    # show version
+    llc version
+
+    echo "saf5400-start: SAF booted successfully!"
+else
+    echo "saf5400-start: SAF is already loaded"
+fi
+
+return 0 2> /dev/null || exit 0

--- a/overlay/usr/sbin/saf5400-stop
+++ b/overlay/usr/sbin/saf5400-stop
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+SAF_DEV_CNT="1"
+
+# check if cw_llc is loaded
+lsmod | grep cw_llc > /dev/null 2>&1
+if [ "$?" = "0" ] ; then
+
+    # get configured transfer mode
+    TRANSFER_MODE=$(cat /sys/module/cw_llc/parameters/TransferMode)
+
+    # send reset to SAFs
+    for i in $(seq 0 $((${SAF_DEV_CNT}-1))); do
+        echo "saf5400-stop: sending reset to SAF $(( i + 1 ))"
+        llc -i ${i} reset > /dev/null 2>&1
+    done
+
+    # set SAF interfaces down
+    for i in $(seq 0 $((${SAF_DEV_CNT}-1))); do
+        echo "saf5400-stop: setting cw-llc${i} down"
+        ip link set cw-llc${i} down > /dev/null 2>&1
+    done
+    sleep 1
+
+    # remove LLC kernel module
+    echo "saf5400-stop: removing LLC kernel module"
+    rmmod cw-llc > /dev/null 2>&1
+
+    echo "saf5400-stop: SAF can be now reloaded"
+else
+    echo "saf5400-stop: SAF is not loaded"
+fi
+
+return 0 2> /dev/null || exit 0

--- a/patches/llc/0001-cw-llc-link-LLC-dev-count-to-cw-llc-makefile.patch
+++ b/patches/llc/0001-cw-llc-link-LLC-dev-count-to-cw-llc-makefile.patch
@@ -1,4 +1,4 @@
-From 8775efb39747198c8ecff43227f441b41d46cc94 Mon Sep 17 00:00:00 2001
+From f12ae605fd05b2b677559d93a4590dbaaf464c40 Mon Sep 17 00:00:00 2001
 From: pferrao <pedro.ferrao@strypes.pt>
 Date: Mon, 4 Oct 2021 10:29:28 +0100
 Subject: [PATCH 01/12] cw-llc: link LLC dev count to cw-llc makefile
@@ -50,5 +50,5 @@ index 7330a78..762e261 100644
  
  //------------------------------------------------------------------------------
 -- 
-2.30.2
+2.39.0
 

--- a/patches/llc/0002-cw-llc-increases-the-list-pool-size.patch
+++ b/patches/llc/0002-cw-llc-increases-the-list-pool-size.patch
@@ -1,4 +1,4 @@
-From d0ad1e5765128ed937c98ee29998d57f8949b0d1 Mon Sep 17 00:00:00 2001
+From 9edfa42757631142b5f7e0e5360437435bec9561 Mon Sep 17 00:00:00 2001
 From: pferrao <pedro.ferrao@strypes.pt>
 Date: Tue, 4 Jan 2022 16:11:07 +0000
 Subject: [PATCH 02/12] cw-llc: increases the list pool size
@@ -21,5 +21,5 @@ index 6cfc661..8add970 100644
  /**
   * @brief  list_for_each_entry_safe - iterate over list of given type safe
 -- 
-2.30.2
+2.39.0
 

--- a/patches/llc/0003-cw-llc-support-for-kernel-5.15-netdev-struct-changes.patch
+++ b/patches/llc/0003-cw-llc-support-for-kernel-5.15-netdev-struct-changes.patch
@@ -1,4 +1,4 @@
-From 19b3d3286988f7fa7f153911b61dd05a1d8031bf Mon Sep 17 00:00:00 2001
+From ed32f22998d07a81ab0786a3a7cea2f6540bb3de Mon Sep 17 00:00:00 2001
 From: pferrao <pedro.ferrao@strypes.pt>
 Date: Thu, 26 May 2022 09:24:43 +0100
 Subject: [PATCH 03/12] cw-llc: support for kernel 5.15 netdev struct changes
@@ -75,5 +75,5 @@ index dbf7604..e09cfb6 100644
    .ndo_change_mtu = LLC_NetDevChangeMTU,
    .ndo_set_mac_address = LLC_NetDevSetMACAddr,
 -- 
-2.30.2
+2.39.0
 

--- a/patches/llc/0004-cw-llc-fix-ethtool-drvinfo-build-error-with-5.15.patch
+++ b/patches/llc/0004-cw-llc-fix-ethtool-drvinfo-build-error-with-5.15.patch
@@ -1,4 +1,4 @@
-From 2a700d6b10667f579a4368701abb4e4e1d24aa93 Mon Sep 17 00:00:00 2001
+From f741a40ceddb7841760054aea202df42eb9a0bb3 Mon Sep 17 00:00:00 2001
 From: Josua Mayer <josua@solid-run.com>
 Date: Sun, 4 Dec 2022 13:03:59 +0200
 Subject: [PATCH 04/12] cw-llc: fix ethtool drvinfo build error with 5.15
@@ -28,5 +28,5 @@ index bbae3ea..6a5c8c2 100644
  // Macros & Constants
  //-----------------------------------------------------------------------------
 -- 
-2.30.2
+2.39.0
 

--- a/patches/llc/0005-cw-llc-support-SolidRun-i.MX8DXL-SoM.patch
+++ b/patches/llc/0005-cw-llc-support-SolidRun-i.MX8DXL-SoM.patch
@@ -1,4 +1,4 @@
-From b84e865712789df53aa0ac11565a4e4de0c4659c Mon Sep 17 00:00:00 2001
+From 65fb5db4b7a86fef1a2e476b293daf4d4778b3f3 Mon Sep 17 00:00:00 2001
 From: Josua Mayer <josua@solid-run.com>
 Date: Sun, 4 Dec 2022 12:44:29 +0200
 Subject: [PATCH 05/12] cw-llc: support SolidRun i.MX8DXL SoM
@@ -21,5 +21,5 @@ index 921b393..6c4400e 100644
  #define LLC_SDIO_ENABLE 1
  #endif
 -- 
-2.30.2
+2.39.0
 

--- a/patches/llc/0006-llc-app-Use-libpcap-from-system.patch
+++ b/patches/llc/0006-llc-app-Use-libpcap-from-system.patch
@@ -1,0 +1,111 @@
+From d6ea043abd15986029e94496473a503397e68b06 Mon Sep 17 00:00:00 2001
+From: Jannik Beyerstedt <beyerstedt@consider-it.de>
+Date: Wed, 21 Dec 2022 09:30:32 +0100
+Subject: [PATCH 06/12] llc app: Use libpcap from system
+
+---
+ app/llc/lib/Makefile | 54 ++------------------------------------------
+ 1 file changed, 2 insertions(+), 52 deletions(-)
+
+diff --git a/app/llc/lib/Makefile b/app/llc/lib/Makefile
+index 0ebbb64..a3a059d 100644
+--- a/app/llc/lib/Makefile
++++ b/app/llc/lib/Makefile
+@@ -10,46 +10,12 @@ else
+   EXTRA_CFLAGS += -O2
+ endif
+ 
+-# PCAP
+-PCAP_SRC_DIR ?= $(CURDIR)/../../../../bsp/app/libpcap
+-PCAP_LIB_DIR := $(CURDIR)/libpcap
+-PCAP_APP_BIN := $(PCAP_LIB_DIR)/libpcap.a
+-
+ # If using yocto/poky toolchain, use CC in environment
+ ifeq (,$(TARGET_PREFIX))
+   CC := "$(CROSS_COMPILE)gcc"
+   CC := $(subst $\",,$(CC))
+ endif
+ 
+-ifneq (,$(findstring $(BOARD),mk5))
+-endif
+-ifneq (,$(findstring $(BOARD),sie))
+-  CROSS_COMPILE := /opt/yocto-1.8.10/x86_64/sysroots/x86_64-siesdk-linux/usr/bin/arm-sie-linux-gnueabi/arm-sie-linux-gnueabi-
+-  CC := "$(CROSS_COMPILE)gcc"
+-  CFLAGS := -march=armv7-a -mfloat-abi=hard -mfpu=neon -mtune=cortex-a9 --sysroot=/opt/yocto-1.8.10/x86_64/sysroots/cortexa9hf-vfp-neon-sie-linux-gnueabi
+-  INSTALLDIR := /tmp/sie
+-  PCAP_SRC_DIR :=
+-  PCAP_LIB_DIR := /opt/yocto-1.8.10/x86_64/sysroots/cortexa9hf-vfp-neon-sie-linux-gnueabi/usr/lib
+-  PCAP_APP_BIN := $(PCAP_LIB_DIR)/libpcap.so
+-endif
+-ifneq (,$(findstring $(BOARD),dgm qnx qnx-arm qnx-x86 mq5 re2q))
+-  QNX_BASE ?= $(HOME)/qnx660
+-  QNX_ENV ?= $(QNX_BASE)/qnx660-env.sh
+-  CC = source $(QNX_ENV); qcc
+-  ifneq (,$(findstring $(BOARD),dgm qnx-arm mq5 re2q))
+-    QCC_OPT = gcc_ntoarmv7le
+-    TARGET = armle-v7
+-  else
+-    QCC_OPT = gcc_ntox86
+-    TARGET = x86
+-  endif
+-  CFLAGS = -V $(QCC_OPT) -DBOARD_$(shell echo $(BOARD) | tr a-z A-Z)
+-  PCAP_SRC_DIR :=
+-  PCAP_LIB_DIR := $(QNX_BASE)/target/qnx6/$(TARGET)/usr/lib
+-  PCAP_APP_BIN := $(PCAP_LIB_DIR)/libpcap.a
+-  COHDA_INCLUDE_DIR ?= ../../../qnx/include
+-endif
+-
+ COHDA_INCLUDE_DIR ?= ../../../kernel/include
+ 
+ # Fallback defaults (host)
+@@ -62,10 +28,9 @@ CFLAGS += -Wall -Werror -MD -shared -fPIC \
+ EXTRA_CFLAGS += -I. \
+                 -I.. \
+                 -I$(COHDA_INCLUDE_DIR) \
+-                -I$(PCAP_LIB_DIR) \
+                 -D__LLC__ \
+ 
+-LDFLAGS += -L$(PCAP_LIB_DIR) -lpcap
++LDFLAGS += -lpcap
+ 
+ LIBS +=
+ 
+@@ -105,10 +70,9 @@ CFLAGS += -DFUZZTEST
+ endif
+ 
+ 
+-$(APP): $(PCAP_APP_BIN) $(LIBS) $(OBJS)
++$(APP): $(LIBS) $(OBJS)
+ 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(OBJS) $(LIBS) $(LDFLAGS) -o $@
+ 	@cp $@ ../
+-	@cp $(PCAP_APP_BIN) ./
+ 
+ %.o: %.c
+ 	-@mkdir --parents $(shell dirname $(DEPDIR)/$*.d)
+@@ -116,23 +80,9 @@ $(APP): $(PCAP_APP_BIN) $(LIBS) $(OBJS)
+ 	@echo $@: Makefile >> $*.d
+ 	@mv -f $*.d $(DEPDIR)/$*.d
+ 
+-$(PCAP_APP_BIN):
+-# only rebuild if we have source for it - we don't on QNX
+-ifneq (,$(PCAP_SRC_DIR))
+-	echo Making $(PCAP_APP_BIN) for $(BOARD)
+-	make -C $(PCAP_SRC_DIR) BOARD=$(BOARD)
+-	rm -rf $(PCAP_LIB_DIR)
+-	ln -s $(PCAP_SRC_DIR)/$(BOARD) $(PCAP_LIB_DIR)
+-endif
+-	test -f $@
+-
+ clean:
+ 	find . -name "*.o" -delete
+ 	rm -f $(APP) $(OBJS) *.o *.so *.so.map ../$(APP)
+-# only remove it we have source for it - we don't on QNX
+-ifneq (,$(PCAP_SRC_DIR))
+-	rm -f ./$(PCAP_APP_BIN) $(PCAP_LIB_DIR)
+-endif
+ 	rm -rf $(DEPDIR)/*
+ 	rm -rf $(DEPDIR)
+ 
+-- 
+2.39.0
+

--- a/patches/llc/0007-llc-app-fix-rcap.so-build-for-debian.patch
+++ b/patches/llc/0007-llc-app-fix-rcap.so-build-for-debian.patch
@@ -1,0 +1,57 @@
+From 92d6789c81933d2fdbe2102e767bf8497094b457 Mon Sep 17 00:00:00 2001
+From: Josua Mayer <josua@solid-run.com>
+Date: Thu, 20 Oct 2022 14:13:01 +0200
+Subject: [PATCH 07/12] llc-app: fix rcap.so build for debian
+
+Debian has the static library in a subdirectory of /usr/lib named by the
+arch and standard library used to build it. Otherwise the rcap.so plugin
+won't be build as dynamically linked library.
+---
+ app/llc/plugin/mcap/Makefile | 6 +++++-
+ app/llc/plugin/rcap/Makefile | 9 ++++++++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/app/llc/plugin/mcap/Makefile b/app/llc/plugin/mcap/Makefile
+index 0de2ca5..18701dd 100644
+--- a/app/llc/plugin/mcap/Makefile
++++ b/app/llc/plugin/mcap/Makefile
+@@ -61,9 +61,13 @@ ifneq ($(strip $(BOARD)),)
+     ROOTFS_DIR        ?= ../../../../../bsp/image/rootfs
+     LIBPCAP_DIR        = $(ROOTFS_DIR)/usr
+     LIBPCAP_INC        = $(LIBPCAP_DIR)/include
+-    LIBPCAP_BIN        = $(LIBPCAP_DIR)/lib/libpcap.a
++    LIBPCAP_BIN        = $(LIBPCAP_DIR)/lib/$(BOARD)-linux-gnu/libpcap.a
+     LDFLAGS           += -L$(LIBPCAP_DIR)/lib -lpcap
+     CFLAGS             = -nostartfiles
++
++  else
++    # overarching makefile will define BOARD ?= $(NATIVE), so we need this here, too
++    KERNELDIR ?= /lib/modules/$(shell uname -r)/build
+   endif
+ 
+ else
+diff --git a/app/llc/plugin/rcap/Makefile b/app/llc/plugin/rcap/Makefile
+index e4df03c..ae6f572 100644
+--- a/app/llc/plugin/rcap/Makefile
++++ b/app/llc/plugin/rcap/Makefile
+@@ -55,9 +55,16 @@ ifneq ($(strip $(BOARD)),)
+     ROOTFS_DIR ?= ../../../../../bsp/image/rootfs
+     LIBPCAP_DIR = $(ROOTFS_DIR)/usr
+     LIBPCAP_INC = $(LIBPCAP_DIR)/include
+-    LIBPCAP_BIN = $(LIBPCAP_DIR)/lib/libpcap.a
++    LIBPCAP_BIN = $(LIBPCAP_DIR)/lib/$(BOARD)-linux-gnu/libpcap.a
+     LDFLAGS    += -L$(LIBPCAP_DIR)/lib -lpcap
+     CFLAGS      = -nostartfiles
++
++  else
++    # overarching makefile will define BOARD ?= $(NATIVE), so we need this here, too
++    KERNELDIR  ?= /lib/modules/$(shell uname -r)/build
++    LIBPCAP_DIR = $(ROOTFS_DIR)/usr
++    LIBPCAP_INC = $(LIBPCAP_DIR)/include
++    LDFLAGS    += -lpcap
+   endif
+ 
+ else
+-- 
+2.39.0
+

--- a/patches/llc/0008-llc-plugins-silence-address-of-packed-member-warning.patch
+++ b/patches/llc/0008-llc-plugins-silence-address-of-packed-member-warning.patch
@@ -1,0 +1,543 @@
+From 03e4c3b19069ab637a049edd433ff46fc273ca74 Mon Sep 17 00:00:00 2001
+From: Jannik Beyerstedt <beyerstedt@consider-it.de>
+Date: Wed, 21 Dec 2022 12:44:09 +0100
+Subject: [PATCH 08/12] llc plugins: silence address-of-packed-member warning
+
+---
+ app/llc/plugin/autocal/Makefile     | 2 +-
+ app/llc/plugin/auxadc/Makefile      | 2 +-
+ app/llc/plugin/bridge/Makefile      | 2 +-
+ app/llc/plugin/calcw/Makefile       | 2 +-
+ app/llc/plugin/capture/Makefile     | 2 +-
+ app/llc/plugin/cbrmon/Makefile      | 2 +-
+ app/llc/plugin/cfg/Makefile         | 2 +-
+ app/llc/plugin/compensator/Makefile | 2 +-
+ app/llc/plugin/config/Makefile      | 2 +-
+ app/llc/plugin/count/Makefile       | 2 +-
+ app/llc/plugin/dbg/Makefile         | 2 +-
+ app/llc/plugin/dmesg/Makefile       | 2 +-
+ app/llc/plugin/dump/Makefile        | 2 +-
+ app/llc/plugin/error/Makefile       | 2 +-
+ app/llc/plugin/fault/Makefile       | 2 +-
+ app/llc/plugin/flush/Makefile       | 2 +-
+ app/llc/plugin/gpio/Makefile        | 2 +-
+ app/llc/plugin/log/Makefile         | 2 +-
+ app/llc/plugin/loop/Makefile        | 2 +-
+ app/llc/plugin/mem/Makefile         | 2 +-
+ app/llc/plugin/ping/Makefile        | 2 +-
+ app/llc/plugin/raw/Makefile         | 2 +-
+ app/llc/plugin/reg/Makefile         | 2 +-
+ app/llc/plugin/reset/Makefile       | 2 +-
+ app/llc/plugin/rx/Makefile          | 2 +-
+ app/llc/plugin/rxphylast/Makefile   | 2 +-
+ app/llc/plugin/safetymon/Makefile   | 2 +-
+ app/llc/plugin/sec/Makefile         | 2 +-
+ app/llc/plugin/simtdapi/Makefile    | 2 +-
+ app/llc/plugin/stats/Makefile       | 2 +-
+ app/llc/plugin/status/Makefile      | 2 +-
+ app/llc/plugin/temp/Makefile        | 2 +-
+ app/llc/plugin/tsf/Makefile         | 2 +-
+ app/llc/plugin/tx/Makefile          | 2 +-
+ app/llc/plugin/txphylast/Makefile   | 2 +-
+ app/llc/plugin/txqueue/Makefile     | 2 +-
+ app/llc/plugin/utc/Makefile         | 2 +-
+ app/llc/plugin/version/Makefile     | 2 +-
+ 38 files changed, 38 insertions(+), 38 deletions(-)
+
+diff --git a/app/llc/plugin/autocal/Makefile b/app/llc/plugin/autocal/Makefile
+index 73dea80..43cee5d 100644
+--- a/app/llc/plugin/autocal/Makefile
++++ b/app/llc/plugin/autocal/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/auxadc/Makefile b/app/llc/plugin/auxadc/Makefile
+index ca474e3..3f12cf7 100644
+--- a/app/llc/plugin/auxadc/Makefile
++++ b/app/llc/plugin/auxadc/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/bridge/Makefile b/app/llc/plugin/bridge/Makefile
+index 2c34602..e64b108 100644
+--- a/app/llc/plugin/bridge/Makefile
++++ b/app/llc/plugin/bridge/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/calcw/Makefile b/app/llc/plugin/calcw/Makefile
+index e76fb4e..5075d14 100644
+--- a/app/llc/plugin/calcw/Makefile
++++ b/app/llc/plugin/calcw/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/capture/Makefile b/app/llc/plugin/capture/Makefile
+index 071c59a..cd2eabd 100644
+--- a/app/llc/plugin/capture/Makefile
++++ b/app/llc/plugin/capture/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/cbrmon/Makefile b/app/llc/plugin/cbrmon/Makefile
+index 20868e2..1d6ee8b 100644
+--- a/app/llc/plugin/cbrmon/Makefile
++++ b/app/llc/plugin/cbrmon/Makefile
+@@ -49,7 +49,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/cfg/Makefile b/app/llc/plugin/cfg/Makefile
+index 0490063..f12e371 100644
+--- a/app/llc/plugin/cfg/Makefile
++++ b/app/llc/plugin/cfg/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/compensator/Makefile b/app/llc/plugin/compensator/Makefile
+index 50300e8..364b6b8 100644
+--- a/app/llc/plugin/compensator/Makefile
++++ b/app/llc/plugin/compensator/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/config/Makefile b/app/llc/plugin/config/Makefile
+index 6a68f53..e553007 100644
+--- a/app/llc/plugin/config/Makefile
++++ b/app/llc/plugin/config/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?= ~
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/count/Makefile b/app/llc/plugin/count/Makefile
+index e7daa3e..c8fc20f 100644
+--- a/app/llc/plugin/count/Makefile
++++ b/app/llc/plugin/count/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/dbg/Makefile b/app/llc/plugin/dbg/Makefile
+index a0c1323..5384e3e 100644
+--- a/app/llc/plugin/dbg/Makefile
++++ b/app/llc/plugin/dbg/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/dmesg/Makefile b/app/llc/plugin/dmesg/Makefile
+index 8eee792..80fabec 100644
+--- a/app/llc/plugin/dmesg/Makefile
++++ b/app/llc/plugin/dmesg/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/dump/Makefile b/app/llc/plugin/dump/Makefile
+index ee28a18..d44d86d 100644
+--- a/app/llc/plugin/dump/Makefile
++++ b/app/llc/plugin/dump/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/error/Makefile b/app/llc/plugin/error/Makefile
+index 05c750c..d05b056 100644
+--- a/app/llc/plugin/error/Makefile
++++ b/app/llc/plugin/error/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/fault/Makefile b/app/llc/plugin/fault/Makefile
+index e918d0e..a553686 100644
+--- a/app/llc/plugin/fault/Makefile
++++ b/app/llc/plugin/fault/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/flush/Makefile b/app/llc/plugin/flush/Makefile
+index 443e2ec..75804a5 100644
+--- a/app/llc/plugin/flush/Makefile
++++ b/app/llc/plugin/flush/Makefile
+@@ -46,7 +46,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/gpio/Makefile b/app/llc/plugin/gpio/Makefile
+index df2a118..8f506d9 100644
+--- a/app/llc/plugin/gpio/Makefile
++++ b/app/llc/plugin/gpio/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/log/Makefile b/app/llc/plugin/log/Makefile
+index 4ca98c3..00bc2a9 100644
+--- a/app/llc/plugin/log/Makefile
++++ b/app/llc/plugin/log/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections -pthread
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/loop/Makefile b/app/llc/plugin/loop/Makefile
+index a1f35e5..db322c6 100644
+--- a/app/llc/plugin/loop/Makefile
++++ b/app/llc/plugin/loop/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections -pthread
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/mem/Makefile b/app/llc/plugin/mem/Makefile
+index af920e5..8efbcda 100644
+--- a/app/llc/plugin/mem/Makefile
++++ b/app/llc/plugin/mem/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/ping/Makefile b/app/llc/plugin/ping/Makefile
+index a27733e..ef9baac 100644
+--- a/app/llc/plugin/ping/Makefile
++++ b/app/llc/plugin/ping/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/raw/Makefile b/app/llc/plugin/raw/Makefile
+index 57c9720..5ddae3c 100644
+--- a/app/llc/plugin/raw/Makefile
++++ b/app/llc/plugin/raw/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/reg/Makefile b/app/llc/plugin/reg/Makefile
+index b038143..4350fca 100644
+--- a/app/llc/plugin/reg/Makefile
++++ b/app/llc/plugin/reg/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/reset/Makefile b/app/llc/plugin/reset/Makefile
+index e9d51f1..6bd564c 100644
+--- a/app/llc/plugin/reset/Makefile
++++ b/app/llc/plugin/reset/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/rx/Makefile b/app/llc/plugin/rx/Makefile
+index 78d69cc..ba27ca0 100644
+--- a/app/llc/plugin/rx/Makefile
++++ b/app/llc/plugin/rx/Makefile
+@@ -49,7 +49,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/rxphylast/Makefile b/app/llc/plugin/rxphylast/Makefile
+index ff2a805..280a08f 100644
+--- a/app/llc/plugin/rxphylast/Makefile
++++ b/app/llc/plugin/rxphylast/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?= ~
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/safetymon/Makefile b/app/llc/plugin/safetymon/Makefile
+index e5e80b1..f1a313c 100644
+--- a/app/llc/plugin/safetymon/Makefile
++++ b/app/llc/plugin/safetymon/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/sec/Makefile b/app/llc/plugin/sec/Makefile
+index fcbb52f..2a83609 100644
+--- a/app/llc/plugin/sec/Makefile
++++ b/app/llc/plugin/sec/Makefile
+@@ -49,7 +49,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/simtdapi/Makefile b/app/llc/plugin/simtdapi/Makefile
+index b7f8390..a88dcc1 100644
+--- a/app/llc/plugin/simtdapi/Makefile
++++ b/app/llc/plugin/simtdapi/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?= ~
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/stats/Makefile b/app/llc/plugin/stats/Makefile
+index 6d0cc0f..226fa37 100644
+--- a/app/llc/plugin/stats/Makefile
++++ b/app/llc/plugin/stats/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/status/Makefile b/app/llc/plugin/status/Makefile
+index f7e4857..92d688a 100644
+--- a/app/llc/plugin/status/Makefile
++++ b/app/llc/plugin/status/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/temp/Makefile b/app/llc/plugin/temp/Makefile
+index 6adce17..f12e300 100644
+--- a/app/llc/plugin/temp/Makefile
++++ b/app/llc/plugin/temp/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/tsf/Makefile b/app/llc/plugin/tsf/Makefile
+index 1a17a18..9518e8c 100644
+--- a/app/llc/plugin/tsf/Makefile
++++ b/app/llc/plugin/tsf/Makefile
+@@ -46,7 +46,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/tx/Makefile b/app/llc/plugin/tx/Makefile
+index 0584c13..daa5600 100644
+--- a/app/llc/plugin/tx/Makefile
++++ b/app/llc/plugin/tx/Makefile
+@@ -49,7 +49,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/txphylast/Makefile b/app/llc/plugin/txphylast/Makefile
+index 77738f9..62d610b 100644
+--- a/app/llc/plugin/txphylast/Makefile
++++ b/app/llc/plugin/txphylast/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?= ~
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/txqueue/Makefile b/app/llc/plugin/txqueue/Makefile
+index 519e68c..7dd57dc 100644
+--- a/app/llc/plugin/txqueue/Makefile
++++ b/app/llc/plugin/txqueue/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/utc/Makefile b/app/llc/plugin/utc/Makefile
+index 1cd948d..1c3dd05 100644
+--- a/app/llc/plugin/utc/Makefile
++++ b/app/llc/plugin/utc/Makefile
+@@ -33,7 +33,7 @@ ifneq ($(TARGET_PREFIX),arm-poky-linux-gnueabi-)
+   CC := $(subst $\",,$(CC))
+ endif
+ 
+-CFLAGS += -Wall -Werror -MD -shared -nostartfiles -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -nostartfiles -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+diff --git a/app/llc/plugin/version/Makefile b/app/llc/plugin/version/Makefile
+index 37d82de..48a6cb5 100644
+--- a/app/llc/plugin/version/Makefile
++++ b/app/llc/plugin/version/Makefile
+@@ -48,7 +48,7 @@ COHDA_INCLUDE_DIR ?= ../../../../kernel/include
+ BOARD ?= $(shell uname --m)
+ INSTALLDIR ?=
+ 
+-CFLAGS += -Wall -Werror -MD -shared -fPIC \
++CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -fPIC \
+          -fdata-sections -ffunction-sections
+ 
+ EXTRA_CFLAGS += -I. \
+-- 
+2.39.0
+

--- a/patches/llc/0009-llc-plugins-Fix-possible-buffer-overflowss.patch
+++ b/patches/llc/0009-llc-plugins-Fix-possible-buffer-overflowss.patch
@@ -1,0 +1,56 @@
+From 24fac4f856ddc49d7b90215e7a580d21b4f15e7a Mon Sep 17 00:00:00 2001
+From: Jannik Beyerstedt <beyerstedt@consider-it.de>
+Date: Wed, 21 Dec 2022 12:10:10 +0100
+Subject: [PATCH 09/12] llc plugins: Fix possible buffer overflowss
+
+---
+ app/llc/plugin/bridge/Opts.h | 6 ++++--
+ app/llc/plugin/udpfwd/Opts.h | 2 +-
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/app/llc/plugin/bridge/Opts.h b/app/llc/plugin/bridge/Opts.h
+index c48e2d8..6bce9fb 100644
+--- a/app/llc/plugin/bridge/Opts.h
++++ b/app/llc/plugin/bridge/Opts.h
+@@ -10,13 +10,15 @@
+ //------------------------------------------------------------------------------
+ #include <stdint.h>
+ #include <stdbool.h>
++#include <net/if.h>
+ 
+ //------------------------------------------------------------------------------
+ // Macros & Constants
+ //------------------------------------------------------------------------------
+ 
+ /// Maximum length of option lists
+-#define OPTS_MAXIFNAMELEN          (64)
++#define OPTS_MAXIFNAMELEN          (IF_NAMESIZE)
++#define OPTS_MAXMACLEN             (18)
+ 
+ //------------------------------------------------------------------------------
+ // Type definitions
+@@ -46,7 +48,7 @@ typedef struct Opts_tag
+   char pInterfaceName[OPTS_MAXIFNAMELEN];
+ 
+   /// MAC Address
+-  char pMACAddress[OPTS_MAXIFNAMELEN];
++  char pMACAddress[OPTS_MAXMACLEN];
+ 
+   /// Channel Number to listen on. Assumes Tx successive SeqNums
+   uint8_t ChannelNumber;
+diff --git a/app/llc/plugin/udpfwd/Opts.h b/app/llc/plugin/udpfwd/Opts.h
+index b02ad6d..bd09da5 100644
+--- a/app/llc/plugin/udpfwd/Opts.h
++++ b/app/llc/plugin/udpfwd/Opts.h
+@@ -87,7 +87,7 @@ typedef struct Opts_tag
+   uint16_t Port;
+ 
+   /// Report File name Special String
+-  char pSpecialString[OPTS_MAXFILENAMELENGTH];
++  char pSpecialString[20];
+ 
+ } tOpts;
+ 
+-- 
+2.39.0
+

--- a/patches/llc/0010-llc-plugins-Support-newer-gpsd-versions.patch
+++ b/patches/llc/0010-llc-plugins-Support-newer-gpsd-versions.patch
@@ -1,0 +1,439 @@
+From 634da1ee09312997cd39ea28c3c27c0adc8c5149 Mon Sep 17 00:00:00 2001
+From: Jannik Beyerstedt <beyerstedt@consider-it.de>
+Date: Wed, 21 Dec 2022 12:18:53 +0100
+Subject: [PATCH 10/12] llc plugins: Support newer gpsd versions
+
+---
+ app/llc/plugin/echo/Makefile       | 16 +---------------
+ app/llc/plugin/echo/llc-echo.c     | 11 ++++++++---
+ app/llc/plugin/rcap/if-gps.c       | 17 +++++++++++------
+ app/llc/plugin/rcap/rcap-tzsp.c    | 13 +++++++------
+ app/llc/plugin/rcap/testpkt-cw14.h |  2 +-
+ app/llc/plugin/udpfwd/Makefile     | 17 +----------------
+ app/llc/plugin/udpfwd/llc-udpfwd.c | 11 ++++++++---
+ app/llc/plugin/udptester/Makefile  | 16 +---------------
+ app/llc/plugin/utc/Makefile        | 19 +------------------
+ app/llc/plugin/utc/llc-utc.c       | 11 ++++++++---
+ 10 files changed, 47 insertions(+), 86 deletions(-)
+
+diff --git a/app/llc/plugin/echo/Makefile b/app/llc/plugin/echo/Makefile
+index e56282c..5a89d4e 100644
+--- a/app/llc/plugin/echo/Makefile
++++ b/app/llc/plugin/echo/Makefile
+@@ -10,11 +10,6 @@ else
+   EXTRA_CFLAGS += -O2
+ endif
+ 
+-# gpsd
+-GPSD_SRC_DIR ?= $(CURDIR)/../../../../../bsp/app/gpsd
+-GPSD_APP_DIR ?= $(CURDIR)/gpsd
+-GPSD_APP_BIN ?= $(GPSD_APP_DIR)/libgps.so
+-
+ # If using yocto/poky toolchain, use CC in environment
+ ifneq ($(TARGET_PREFIX),arm-poky-linux-gnueabi-)
+ CC := "$(CROSS_COMPILE)gcc"
+@@ -59,11 +54,10 @@ EXTRA_CFLAGS += -I. \
+                 -I../.. \
+                 -I../../lib \
+                 -I../../../pktbuf \
+-                -I$(GPSD_APP_DIR) \
+                 -I$(COHDA_INCLUDE_DIR) \
+                 -D__LLC__ -DBOARD_$(shell echo $(BOARD) | tr a-z A-Z)
+ 
+-LDFLAGS += -L$(GPSD_APP_DIR) -lgps -lstdc++ \
++LDFLAGS += -lgps -lstdc++ \
+            -L$(CURDIR)/../../lib -lLLC -lpcap
+ 
+ LIBS +=
+@@ -79,20 +73,12 @@ $(APP): $(LIBS) $(OBJS)
+ 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(OBJS) $(LIBS) $(LDFLAGS) -o $@
+ 	@cp $@ ../
+ 
+-$(OBJS): $(GPSD_APP_BIN)
+-
+ %.o: %.c
+ 	-@mkdir --parents $(shell dirname $(DEPDIR)/$*.d)
+ 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -c $< -o $@
+ 	@echo $@: Makefile >> $*.d
+ 	@mv -f $*.d $(DEPDIR)/$*.d
+ 
+-$(GPSD_APP_BIN):
+-	make -C $(GPSD_SRC_DIR) BOARD=$(BOARD)
+-	rm -f $(GPSD_APP_DIR)
+-	ln -s $(GPSD_SRC_DIR)/$(BOARD) $(GPSD_APP_DIR)
+-	test -f $@
+-
+ clean:
+ 	rm -f $(APP) $(OBJS) *.o *.so *.so.map
+ 	rm -f $(GPSD_APP_DIR)
+diff --git a/app/llc/plugin/echo/llc-echo.c b/app/llc/plugin/echo/llc-echo.c
+index 519997f..2a73ae3 100644
+--- a/app/llc/plugin/echo/llc-echo.c
++++ b/app/llc/plugin/echo/llc-echo.c
+@@ -307,13 +307,18 @@ static int LLC_GPSRecv (struct LLCEcho *pDev)
+ 
+   // We're not so concerned about fix quality, but
+   // rather just the time
+-  if ((pDev->pGPS->status < 0) ||
++#if GPSD_API_MAJOR_VERSION >= 10
++  int gpsStatus = pDev->pGPS->fix.status;
++#else
++  int gpsStatus = pDev->pGPS->status;
++#endif
++  if ((gpsStatus < 0) ||
+       (pDev->pGPS->fix.mode < 2))
+   {
+     // Unacceptable fix
+     if (pDev->pGPS->set & MODE_SET)
+       d_printf(D_INFO, NULL, "No GPS signal: mode %d status %d\n",
+-               pDev->pGPS->fix.mode, pDev->pGPS->status);
++               pDev->pGPS->fix.mode, gpsStatus);
+     // else, some other version or device info, don't care
+     Res = -EINVAL;
+     goto Error;
+@@ -334,7 +339,7 @@ static int LLC_GPSRecv (struct LLCEcho *pDev)
+   }
+ 
+   // convert the time into microseconds
+-  MicroSec = (uint64_t)(pDev->pGPS->fix.time * LLC_ECHO_MICROSEC_PER_SEC);
++  MicroSec = (uint64_t)(pDev->pGPS->fix.time.tv_sec * LLC_ECHO_MICROSEC_PER_SEC);
+ 
+   (void) gettimeofday(&Time, NULL);
+   Now = (Time.tv_sec * LLC_ECHO_MICROSEC_PER_SEC) + Time.tv_usec;
+diff --git a/app/llc/plugin/rcap/if-gps.c b/app/llc/plugin/rcap/if-gps.c
+index f800981..d707565 100644
+--- a/app/llc/plugin/rcap/if-gps.c
++++ b/app/llc/plugin/rcap/if-gps.c
+@@ -119,7 +119,7 @@ int GPSInit(struct ifGPSData * pGPS,
+   #elif (defined(BOARD_RE2L) || defined(BOARD_RE2Q))
+   pGPS->GpsCache = (tGPSInfo) {NAN, {NAN,0,0,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN},0,-1,0,NAN};
+   #else
+-  pGPS->GpsCache = (tGPSInfo) {NAN, {NAN,0,0,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN},0,-1,0,NAN};
++  pGPS->GpsCache = (tGPSInfo) {NAN, {{0,0},0,0,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN,NAN},0,-1,0,NAN};
+   #endif
+ 
+   // attempt to attach to the gpsd and create pGpsData object
+@@ -225,7 +225,7 @@ int GPSUpdate(struct ifGPSData * pGPS,
+ 
+   d_printf(D_DEBUG, NULL, "gps: mode %d, time %f, lat %f, lon %f, alt %f, head %f, speed %f\n",
+            Fix->mode,
+-           Fix->time,
++           (Fix->time.tv_sec + Fix->time.tv_nsec / (double)1E9),
+            Fix->latitude,
+            Fix->longitude,
+            Fix->altitude,
+@@ -233,11 +233,16 @@ int GPSUpdate(struct ifGPSData * pGPS,
+            Fix->speed);
+ 
+   // Set a mimnimum level for fix quality
+-  if ((Fix->mode        <= MODE_NO_FIX) ||
+-      (pGPS->pGpsData->status == STATUS_NO_FIX))
++#if GPSD_API_MAJOR_VERSION >= 10
++  int gpsStatus = pGPS->pGpsData->fix.status;
++#else
++  int gpsStatus = pGPS->pGpsData->status;
++#endif
++  if ((Fix->mode <= MODE_NO_FIX) ||
++      (gpsStatus == STATUS_NO_FIX))
+   {
+     d_printf(D_DEBUG, NULL, "No GPS fix (%d,%d)\n",
+-             Fix->mode, pGPS->pGpsData->status);
++             Fix->mode, gpsStatus);
+     // No fix at all, ensure all data updated with 'no position'
+     LocalSet = GPS_REQUIRED_SET_BITS;
+   }
+@@ -248,7 +253,7 @@ int GPSUpdate(struct ifGPSData * pGPS,
+   // Update cache with available fields
+ 
+   if (LocalSet & ONLINE_SET)
+-    pGPS->GpsCache.Online        = pGPS->pGpsData->online;
++    pGPS->GpsCache.Online        = (pGPS->pGpsData->online.tv_sec + pGPS->pGpsData->online.tv_nsec / (double)1E9);
+   if (LocalSet & TIME_SET)
+   {
+     pGPS->GpsCache.Fix.time      = Fix->time;
+diff --git a/app/llc/plugin/rcap/rcap-tzsp.c b/app/llc/plugin/rcap/rcap-tzsp.c
+index 6b4dce6..f8d5b9d 100644
+--- a/app/llc/plugin/rcap/rcap-tzsp.c
++++ b/app/llc/plugin/rcap/rcap-tzsp.c
+@@ -1460,13 +1460,13 @@ void GeneratePosFromFix(struct gps_fix_t *pFix,
+   uint16_t TmpSpeed = 0;
+ //  uint16_t TmpAcceleration = 0; // @todo Acceleration
+ 
+-  if (!isnan(pFix->time))
++  if (pFix->time.tv_sec != 0)
+   {
+     // SecMark
+     struct timeval Time;
+     // Convert GPS time to constituent parts
+-    Time.tv_sec = pFix->time;
+-    Time.tv_usec = (1e6*(pFix->time - (uint32_t)pFix->time))+1;
++    Time.tv_sec = pFix->time.tv_sec;
++    Time.tv_usec = pFix->time.tv_nsec / 1000;
+     // Calculate milliseconds since minute start
+     TmpSecMark = ((Time.tv_sec % 60) * 1000) + (Time.tv_usec / 1000);
+ 
+@@ -1860,9 +1860,10 @@ int RCap_Forwarding (struct RCap *pRCap)
+           {
+             bool NewFix = false;
+             // Only update if the fix time has changed
+-            if (pRCap->GPS.Fix.time != PosLastUpdateTime)
++            double fixTimeSec = pRCap->GPS.Fix.time.tv_sec + (pRCap->GPS.Fix.time.tv_nsec / (double)1E9);
++            if (fixTimeSec != PosLastUpdateTime)
+             {
+-              PosLastUpdateTime = pRCap->GPS.Fix.time;
++              PosLastUpdateTime = fixTimeSec;
+               NewFix = true;
+               // final check - ignore if we have no fix
+               if (pRCap->GPS.Fix.mode <= MODE_NO_FIX)
+@@ -1875,7 +1876,7 @@ int RCap_Forwarding (struct RCap *pRCap)
+                 pRCap->Opts.RxPosFixedLat,
+                 pRCap->Opts.RxPosFixedLong,
+                 pRCap->Opts.RxPosFixedElev,
+-                pRCap->GPS.Fix.time, // use the current synchronised gps time
++                fixTimeSec, // use the current synchronised gps time
+                 &(pRCap->CurPos));
+             else
+               GeneratePosFromFix(&pRCap->GPS.Fix,
+diff --git a/app/llc/plugin/rcap/testpkt-cw14.h b/app/llc/plugin/rcap/testpkt-cw14.h
+index d9fe25b..ed693eb 100644
+--- a/app/llc/plugin/rcap/testpkt-cw14.h
++++ b/app/llc/plugin/rcap/testpkt-cw14.h
+@@ -443,7 +443,7 @@ static inline int TestPkt_CW14_GPS_LogToFile(const struct GPSInfo * pGPSInfo,
+   double LocalTime_s = LocalTime.tv_sec + LocalTime.tv_nsec*1e-9;
+   ret = fprintf(pFile, "%16.6f,%16.6f,%11.6f,%11.6f,%7.2f,%6.2f\n",
+                 LocalTime_s,
+-                pFix->time,
++                (pFix->time.tv_sec + pFix->time.tv_sec / (double)1E6),
+                 pFix->latitude,
+                 pFix->longitude,
+                 pFix->track,
+diff --git a/app/llc/plugin/udpfwd/Makefile b/app/llc/plugin/udpfwd/Makefile
+index f4b91d6..c695597 100644
+--- a/app/llc/plugin/udpfwd/Makefile
++++ b/app/llc/plugin/udpfwd/Makefile
+@@ -10,11 +10,6 @@ else
+   EXTRA_CFLAGS += -O2
+ endif
+ 
+-# gpsd
+-GPSD_SRC_DIR ?= $(CURDIR)/../../../../../bsp/app/gpsd
+-GPSD_APP_DIR ?= $(CURDIR)/gpsd
+-GPSD_APP_BIN ?= $(GPSD_APP_DIR)/libgps.so
+-
+ # If using yocto/poky toolchain, use CC in environment
+ ifneq ($(TARGET_PREFIX),arm-poky-linux-gnueabi-)
+ CC := "$(CROSS_COMPILE)gcc"
+@@ -59,11 +54,10 @@ EXTRA_CFLAGS += -I. \
+                 -I../.. \
+                 -I../../lib \
+                 -I../../../pktbuf \
+-                -I$(GPSD_APP_DIR) \
+                 -I$(COHDA_INCLUDE_DIR) \
+                 -D__LLC__ -DBOARD_$(shell echo $(BOARD) | tr a-z A-Z)
+ 
+-LDFLAGS += -L$(GPSD_APP_DIR) -lgps  -lstdc++ \
++LDFLAGS += -lgps  -lstdc++ \
+            -L$(CURDIR)/../../lib -lLLC -lpcap
+ 
+ LIBS +=
+@@ -79,23 +73,14 @@ $(APP): $(LIBS) $(OBJS)
+ 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(OBJS) $(LIBS) $(LDFLAGS) -o $@
+ 	@cp $@ ../
+ 
+-$(OBJS): $(GPSD_APP_BIN)
+-
+ %.o: %.c
+ 	-@mkdir --parents $(shell dirname $(DEPDIR)/$*.d)
+ 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -c $< -o $@
+ 	@echo $@: Makefile >> $*.d
+ 	@mv -f $*.d $(DEPDIR)/$*.d
+ 
+-$(GPSD_APP_BIN):
+-	make -C $(GPSD_SRC_DIR) BOARD=$(BOARD)
+-	rm -f $(GPSD_APP_DIR)
+-	ln -s $(GPSD_SRC_DIR)/$(BOARD) $(GPSD_APP_DIR)
+-	test -f $@
+-
+ clean:
+ 	rm -f $(APP) $(OBJS) *.o *.so *.so.map
+-	rm -f $(GPSD_APP_DIR)
+ 	rm -rf $(DEPDIR)/*
+ 	rm -rf $(DEPDIR)
+ 
+diff --git a/app/llc/plugin/udpfwd/llc-udpfwd.c b/app/llc/plugin/udpfwd/llc-udpfwd.c
+index 0f661a2..afa065f 100644
+--- a/app/llc/plugin/udpfwd/llc-udpfwd.c
++++ b/app/llc/plugin/udpfwd/llc-udpfwd.c
+@@ -442,13 +442,18 @@ static int LLC_GPSRecv (struct LLCUDPFWD *pDev)
+ 
+   // We're not so concerned about fix quality, but
+   // rather just the time
+-  if ((pDev->pGPS->status < 0) ||
++#if GPSD_API_MAJOR_VERSION >= 10
++  int gpsStatus = pDev->pGPS->fix.status;
++#else
++  int gpsStatus = pDev->pGPS->status;
++#endif
++  if ((gpsStatus < 0) ||
+       (pDev->pGPS->fix.mode < 2))
+   {
+     // Unacceptable fix
+     if (pDev->pGPS->set & MODE_SET)
+       d_printf(D_INFO, NULL, "No GPS signal: mode %d status %d\n",
+-               pDev->pGPS->fix.mode, pDev->pGPS->status);
++               pDev->pGPS->fix.mode, gpsStatus);
+     // else, some other version or device info, don't care
+     Res = -EINVAL;
+     goto Error;
+@@ -469,7 +474,7 @@ static int LLC_GPSRecv (struct LLCUDPFWD *pDev)
+   }
+ 
+   // convert the time into microseconds
+-  MicroSec = (uint64_t)(pDev->pGPS->fix.time * LLC_UDPFWD_MICROSEC_PER_SEC);
++  MicroSec = (uint64_t)(pDev->pGPS->fix.time.tv_sec * 1E3 + pDev->pGPS->fix.time.tv_nsec / 1E6);
+ 
+   (void) gettimeofday(&Time, NULL);
+   Now = (Time.tv_sec * LLC_UDPFWD_MICROSEC_PER_SEC) + Time.tv_usec;
+diff --git a/app/llc/plugin/udptester/Makefile b/app/llc/plugin/udptester/Makefile
+index ffb5fe0..02c3239 100644
+--- a/app/llc/plugin/udptester/Makefile
++++ b/app/llc/plugin/udptester/Makefile
+@@ -10,11 +10,6 @@ else
+   EXTRA_CFLAGS += -O2
+ endif
+ 
+-# gpsd
+-GPSD_SRC_DIR ?= $(CURDIR)/../../../../../bsp/app/gpsd
+-GPSD_APP_DIR ?= $(CURDIR)/gpsd
+-GPSD_APP_BIN ?= $(GPSD_APP_DIR)/libgps.so
+-
+ # If using yocto/poky toolchain, use CC in environment
+ ifneq ($(TARGET_PREFIX),arm-poky-linux-gnueabi-)
+ CC := "$(CROSS_COMPILE)gcc"
+@@ -59,11 +54,10 @@ EXTRA_CFLAGS += -I. \
+                 -I../.. \
+                 -I../../lib \
+                 -I../../../pktbuf \
+-                -I$(GPSD_APP_DIR) \
+                 -I$(COHDA_INCLUDE_DIR) \
+                 -D__LLC__ -DBOARD_$(shell echo $(BOARD) | tr a-z A-Z)
+ 
+-LDFLAGS += -L$(GPSD_APP_DIR) -lgps \
++LDFLAGS += -lgps \
+            -L$(CURDIR)/../../lib -lLLC -lpcap
+ 
+ LIBS +=
+@@ -79,7 +73,6 @@ $(APP): $(LIBS) $(OBJS)
+ 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(OBJS) $(LIBS) $(LDFLAGS) -o $@
+ 	@cp $@ ../
+ 
+-$(OBJS): $(GPSD_APP_BIN)
+ 
+ %.o: %.c
+ 	-@mkdir --parents $(shell dirname $(DEPDIR)/$*.d)
+@@ -87,15 +80,8 @@ $(OBJS): $(GPSD_APP_BIN)
+ 	@echo $@: Makefile >> $*.d
+ 	@mv -f $*.d $(DEPDIR)/$*.d
+ 
+-$(GPSD_APP_BIN):
+-	make -C $(GPSD_SRC_DIR) BOARD=$(BOARD)
+-	rm -f $(GPSD_APP_DIR)
+-	ln -s $(GPSD_SRC_DIR)/$(BOARD) $(GPSD_APP_DIR)
+-	test -f $@
+-
+ clean:
+ 	rm -f $(APP) $(OBJS) *.o *.so *.so.map
+-	rm -f $(GPSD_APP_DIR)
+ 	rm -rf $(DEPDIR)/*
+ 	rm -rf $(DEPDIR)
+ 
+diff --git a/app/llc/plugin/utc/Makefile b/app/llc/plugin/utc/Makefile
+index 1c3dd05..6c2b844 100644
+--- a/app/llc/plugin/utc/Makefile
++++ b/app/llc/plugin/utc/Makefile
+@@ -10,11 +10,6 @@ else
+   EXTRA_CFLAGS += -O2
+ endif
+ 
+-# gpsd
+-GPSD_SRC_DIR ?= $(CURDIR)/../../../../../bsp/app/gpsd
+-GPSD_APP_DIR ?= $(CURDIR)/gpsd
+-GPSD_APP_BIN ?= $(GPSD_APP_DIR)/libgps.so
+-
+ ifeq ($(BOARD),mk2)
+ endif
+ ifeq ($(BOARD),mk4)
+@@ -39,10 +34,9 @@ CFLAGS += -Wall -Werror -Wno-error=address-of-packed-member -MD -shared -nostart
+ EXTRA_CFLAGS += -I. \
+                 -I../.. \
+                 -I../../../../kernel/include \
+-                -I$(GPSD_APP_DIR) \
+                 -D__LLC__ -DBOARD_$(shell echo $(BOARD) | tr a-z A-Z)
+ 
+-LDFLAGS += -L$(GPSD_APP_DIR) -lgps -lstdc++ -lm \
++LDFLAGS += -lgps -lstdc++ -lm \
+            -L$(CURDIR)/../../lib -lLLC -lpcap
+ 
+ LIBS +=
+@@ -58,25 +52,14 @@ $(APP): $(LIBS) $(OBJS)
+ 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(OBJS) $(LIBS) $(LDFLAGS) -o $@
+ 	@cp $@ ../
+ 
+-$(OBJS): $(GPSD_APP_BIN)
+-
+ %.o: %.c
+ 	-@mkdir --parents $(shell dirname $(DEPDIR)/$*.d)
+ 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -c $< -o $@
+ 	@echo $@: Makefile >> $*.d
+ 	@mv -f $*.d $(DEPDIR)/$*.d
+ 
+-$(GPSD_APP_BIN):
+-ifneq ($(TARGET_PREFIX),arm-poky-linux-gnueabi-)
+-	make -C $(GPSD_SRC_DIR) BOARD=$(BOARD)
+-endif
+-	rm -f $(GPSD_APP_DIR)
+-	ln -s $(GPSD_SRC_DIR)/$(BOARD) $(GPSD_APP_DIR)
+-	test -f $@
+-
+ clean:
+ 	rm -f $(APP) $(OBJS) *.o *.so *.so.map
+-	rm -f $(GPSD_APP_DIR)
+ 	rm -rf $(DEPDIR)/*
+ 	rm -rf $(DEPDIR)
+ 
+diff --git a/app/llc/plugin/utc/llc-utc.c b/app/llc/plugin/utc/llc-utc.c
+index 0aecafd..b668265 100644
+--- a/app/llc/plugin/utc/llc-utc.c
++++ b/app/llc/plugin/utc/llc-utc.c
+@@ -396,12 +396,17 @@ static int LLC_UTCRecv (struct LLCUTC *pDev)
+   }
+ 
+   // We're not so concerned about fix quality, but rather just the time
+-  if ((pDev->pGPS->status < 0) || (pDev->pGPS->fix.mode < 2))
++#if GPSD_API_MAJOR_VERSION >= 10
++  int gpsStatus = pDev->pGPS->fix.status;
++#else
++  int gpsStatus = pDev->pGPS->status;
++#endif
++  if ((gpsStatus < 0) || (pDev->pGPS->fix.mode < 2))
+   {
+     // Unacceptable fix
+     if (pDev->pGPS->set & MODE_SET)
+       d_printf(D_INFO, NULL, "No GPS signal: mode %d status %d\n",
+-               pDev->pGPS->fix.mode, pDev->pGPS->status);
++               pDev->pGPS->fix.mode, gpsStatus);
+     // else, some other version or device info, don't care
+     Res = -EINVAL;
+     goto Error;
+@@ -421,7 +426,7 @@ static int LLC_UTCRecv (struct LLCUTC *pDev)
+   }
+ 
+   // convert the time into microseconds
+-  MicroSec = (uint64_t)(pDev->pGPS->fix.time * LLC_UTC_MICROSEC_PER_SEC);
++  MicroSec = (uint64_t)(pDev->pGPS->fix.time.tv_sec * 1E3 + pDev->pGPS->fix.time.tv_nsec / 1E6);
+ 
+   // Debug output of delta between UTC and current time
+   if (d_test(D_DBG))
+-- 
+2.39.0
+

--- a/patches/llc/0011-llc-plugins-Fix-internal-API-changes.patch
+++ b/patches/llc/0011-llc-plugins-Fix-internal-API-changes.patch
@@ -1,0 +1,66 @@
+From a7dff520136f74d00067683daaf01014e41d7234 Mon Sep 17 00:00:00 2001
+From: Jannik Beyerstedt <beyerstedt@consider-it.de>
+Date: Wed, 21 Dec 2022 12:20:19 +0100
+Subject: [PATCH 11/12] llc plugins: Fix internal API changes
+
+Some things were changed in the internal helper functions, but not
+everywhere.
+---
+ app/llc/plugin/udptester/test-common.c | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/app/llc/plugin/udptester/test-common.c b/app/llc/plugin/udptester/test-common.c
+index e2e0516..e95a22e 100644
+--- a/app/llc/plugin/udptester/test-common.c
++++ b/app/llc/plugin/udptester/test-common.c
+@@ -51,7 +51,7 @@
+ // Functions
+ //------------------------------------------------------------------------------
+ 
+-void MACAddr_fprintf (FILE *fp, uint8_t * pAddr)
++void MACAddr_fprintf (FILE *fp, const uint8_t * pAddr)
+ {
+   fprintf(fp, "%02x:%02x:%02x:%02x:%02x:%02x ", pAddr[0], pAddr[1], pAddr[2],
+           pAddr[3], pAddr[4], pAddr[5]);
+@@ -64,7 +64,7 @@ void MACAddr_fprintf (FILE *fp, uint8_t * pAddr)
+  * @return none
+  * Print headings if input data pointer is NULL
+  */
+-void EthHdr_fprintf (FILE *fp, struct ethhdr * pEthHdr)
++void EthHdr_fprintf (FILE *fp, const struct ethhdr * pEthHdr)
+ {
+   if (pEthHdr == NULL)
+   {
+@@ -102,10 +102,10 @@ void Dot11Hdr_fprintf (FILE *fp, struct IEEE80211MACHdr * pDot11Hdr)
+     fprintf(fp, "%6s ", "FrmCtl");
+     /// Duration ID, for data frames = duration of frames
+     fprintf(fp, "%6s ", "DurnID");
+-    /// SA Source address
+-    fprintf(fp, "%17s ", "Address 1");
+-    /// DA Destination address
+-    fprintf(fp, "%17s ", "Address 2");
++    /// SA Destination address
++    fprintf(fp, "%17s ", "DestinationAddress");
++    /// DA Source address
++    fprintf(fp, "%17s ", "SourceAddress");
+     /// BSSID Receiving station address (destination wireless station)
+     fprintf(fp, "%17s ", "Address 3");
+     /// Sequence control info
+@@ -118,10 +118,10 @@ void Dot11Hdr_fprintf (FILE *fp, struct IEEE80211MACHdr * pDot11Hdr)
+     fprintf(fp, "0x%04x ", ntohs(pDot11Hdr->FrameControl));
+     /// Duration ID, for data frames = duration of frames
+     fprintf(fp, "0x%04x ", ntohs(pDot11Hdr->DurationId));
+-    /// SA Source address
+-    MACAddr_fprintf(fp, pDot11Hdr->Address1);
+-    /// DA Destination address
+-    MACAddr_fprintf(fp, pDot11Hdr->Address2);
++    /// SA Destination address
++    MACAddr_fprintf(fp, pDot11Hdr->DestinationAddress);
++    /// DA Source address
++    MACAddr_fprintf(fp, pDot11Hdr->SourceAddress);
+     /// BSSID Receiving station address (destination wireless station)
+     MACAddr_fprintf(fp, pDot11Hdr->Address3);
+     /// Sequence control info
+-- 
+2.39.0
+

--- a/patches/llc/0012-llc-plugins-Fix-include-paths.patch
+++ b/patches/llc/0012-llc-plugins-Fix-include-paths.patch
@@ -1,0 +1,184 @@
+From 0f063da1f9ea36f8269524b7b3eaa4b902e08570 Mon Sep 17 00:00:00 2001
+From: Jannik Beyerstedt <beyerstedt@consider-it.de>
+Date: Wed, 21 Dec 2022 12:53:30 +0100
+Subject: [PATCH 12/12] llc plugins: Fix include paths
+
+---
+ app/llc/plugin/calib/Conf_Dump.c  | 2 +-
+ app/llc/plugin/calib/Conf_Dump.h  | 2 +-
+ app/llc/plugin/calib/Conf_Parse.c | 2 +-
+ app/llc/plugin/calib/Conf_Parse.h | 2 +-
+ app/llc/plugin/cfg/Conf_Dump.c    | 2 +-
+ app/llc/plugin/cfg/Conf_Dump.h    | 2 +-
+ app/llc/plugin/cfg/Conf_Parse.c   | 2 +-
+ app/llc/plugin/cfg/Conf_Parse.h   | 2 +-
+ app/llc/plugin/mcap/Makefile      | 4 ++--
+ app/llc/plugin/stats/Conf_Dump.c  | 2 +-
+ app/llc/plugin/stats/Conf_Dump.h  | 2 +-
+ app/llc/plugin/stats/Conf_Parse.c | 2 +-
+ app/llc/plugin/stats/Conf_Parse.h | 2 +-
+ 13 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/app/llc/plugin/calib/Conf_Dump.c b/app/llc/plugin/calib/Conf_Dump.c
+index 4744114..c5befa2 100644
+--- a/app/llc/plugin/calib/Conf_Dump.c
++++ b/app/llc/plugin/calib/Conf_Dump.c
+@@ -1,6 +1,6 @@
+ 
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #include <inttypes.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/app/llc/plugin/calib/Conf_Dump.h b/app/llc/plugin/calib/Conf_Dump.h
+index 004f906..8cab99b 100644
+--- a/app/llc/plugin/calib/Conf_Dump.h
++++ b/app/llc/plugin/calib/Conf_Dump.h
+@@ -1,5 +1,5 @@
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #define FAILURE 1
+ #define SUCCESS 0
+ void tMKxCalibrationData_Dump(char *pStr, tMKxCalibrationData *pInput);
+diff --git a/app/llc/plugin/calib/Conf_Parse.c b/app/llc/plugin/calib/Conf_Parse.c
+index e3ba2b6..bdefc25 100644
+--- a/app/llc/plugin/calib/Conf_Parse.c
++++ b/app/llc/plugin/calib/Conf_Parse.c
+@@ -1,6 +1,6 @@
+ 
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #include <inttypes.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/app/llc/plugin/calib/Conf_Parse.h b/app/llc/plugin/calib/Conf_Parse.h
+index 9e49f3e..9c687c2 100644
+--- a/app/llc/plugin/calib/Conf_Parse.h
++++ b/app/llc/plugin/calib/Conf_Parse.h
+@@ -1,5 +1,5 @@
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #define FAILURE 1
+ #define SUCCESS 0
+ uint32_t tMKxCalibrationData_Parse(const char *pKey, const char *pValue, tMKxCalibrationData *pParse);
+diff --git a/app/llc/plugin/cfg/Conf_Dump.c b/app/llc/plugin/cfg/Conf_Dump.c
+index 017bfc9..22dc190 100644
+--- a/app/llc/plugin/cfg/Conf_Dump.c
++++ b/app/llc/plugin/cfg/Conf_Dump.c
+@@ -1,6 +1,6 @@
+ 
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #include <inttypes.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/app/llc/plugin/cfg/Conf_Dump.h b/app/llc/plugin/cfg/Conf_Dump.h
+index 05dde1c..f9c90fd 100644
+--- a/app/llc/plugin/cfg/Conf_Dump.h
++++ b/app/llc/plugin/cfg/Conf_Dump.h
+@@ -1,5 +1,5 @@
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #define FAILURE 1
+ #define SUCCESS 0
+ void tMKxChanConfig_Dump(char *pStr, tMKxChanConfig *pInput);
+diff --git a/app/llc/plugin/cfg/Conf_Parse.c b/app/llc/plugin/cfg/Conf_Parse.c
+index e7dc142..b3c71f1 100644
+--- a/app/llc/plugin/cfg/Conf_Parse.c
++++ b/app/llc/plugin/cfg/Conf_Parse.c
+@@ -1,6 +1,6 @@
+ 
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #include <inttypes.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/app/llc/plugin/cfg/Conf_Parse.h b/app/llc/plugin/cfg/Conf_Parse.h
+index 3b1a241..2b2a91f 100644
+--- a/app/llc/plugin/cfg/Conf_Parse.h
++++ b/app/llc/plugin/cfg/Conf_Parse.h
+@@ -1,5 +1,5 @@
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #define FAILURE 1
+ #define SUCCESS 0
+ uint32_t tMKxChanConfig_Parse(const char *pKey, const char *pValue, tMKxChanConfig *pParse);
+diff --git a/app/llc/plugin/mcap/Makefile b/app/llc/plugin/mcap/Makefile
+index 18701dd..03f9487 100644
+--- a/app/llc/plugin/mcap/Makefile
++++ b/app/llc/plugin/mcap/Makefile
+@@ -6,7 +6,7 @@ PWD	= $(shell pwd)
+ 
+ # are we building as plugin for llc or for cw-tool
+ ifneq (,$(findstring llc,$(PWD)))
+-  COMMON_DIR         = $(PWD)/../../../../..
++  COMMON_DIR         = $(PWD)/../../../..
+   PLUGIN_INCLUDE_DIR = ../../
+   PLUGIN_DEST        = ../
+ 
+@@ -17,7 +17,7 @@ else
+   PLUGIN_DEST        = ../cw-tool/src/plugin
+ endif
+ 
+-COHDA_DIR         = $(COMMON_DIR)/cohda
++COHDA_DIR         = $(COMMON_DIR)
+ COHDA_INCLUDE_DIR = $(COHDA_DIR)/kernel/include
+ 
+ # Comment/uncomment the following line to disable/enable debugging
+diff --git a/app/llc/plugin/stats/Conf_Dump.c b/app/llc/plugin/stats/Conf_Dump.c
+index 93ab9f6..ab65df8 100644
+--- a/app/llc/plugin/stats/Conf_Dump.c
++++ b/app/llc/plugin/stats/Conf_Dump.c
+@@ -1,6 +1,6 @@
+ 
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #include <inttypes.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/app/llc/plugin/stats/Conf_Dump.h b/app/llc/plugin/stats/Conf_Dump.h
+index bd03888..2afefed 100644
+--- a/app/llc/plugin/stats/Conf_Dump.h
++++ b/app/llc/plugin/stats/Conf_Dump.h
+@@ -1,5 +1,5 @@
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #define FAILURE 1
+ #define SUCCESS 0
+ void tMKxRadioStatsData_Dump(char *pStr, tMKxRadioStatsData *pInput);
+diff --git a/app/llc/plugin/stats/Conf_Parse.c b/app/llc/plugin/stats/Conf_Parse.c
+index 757e93a..ce55000 100644
+--- a/app/llc/plugin/stats/Conf_Parse.c
++++ b/app/llc/plugin/stats/Conf_Parse.c
+@@ -1,6 +1,6 @@
+ 
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #include <inttypes.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/app/llc/plugin/stats/Conf_Parse.h b/app/llc/plugin/stats/Conf_Parse.h
+index 7746810..eca92f2 100644
+--- a/app/llc/plugin/stats/Conf_Parse.h
++++ b/app/llc/plugin/stats/Conf_Parse.h
+@@ -1,5 +1,5 @@
+ #define _GNU_SOURCE
+-#include "llc-api.h"
++#include "cohda/llc/llc-api.h"
+ #define FAILURE 1
+ #define SUCCESS 0
+ uint32_t tMKxRadioStatsData_Parse(const char *pKey, const char *pValue, tMKxRadioStatsData *pParse);
+-- 
+2.39.0
+

--- a/patches/safboot/0001-v2x-saf-boot-Add-support-for-SolidRun-i.MX8DXL-SoM.patch
+++ b/patches/safboot/0001-v2x-saf-boot-Add-support-for-SolidRun-i.MX8DXL-SoM.patch
@@ -1,0 +1,105 @@
+From 7861a1b5434a0d2805b72f436c81ed6b0dcd2934 Mon Sep 17 00:00:00 2001
+From: Jannik Beyerstedt <beyerstedt@consider-it.de>
+Date: Wed, 21 Dec 2022 13:47:24 +0100
+Subject: [PATCH 1/2] v2x-saf-boot: Add support for SolidRun i.MX8DXL SoM
+
+---
+ v2xHostPal/v2xEvoBootGlobalCnf.mk             | 12 ++++++++++
+ v2xHostPal/v2xHostDal/inc/v2xHostDalBoot.h    | 22 +++++++++++++++++++
+ .../v2xHostDal/inc/v2xHostDalCommonTypes.h    |  1 +
+ v2xHostPal/v2xHostDal/inc/v2xHostDalSdio.h    |  4 ++++
+ 4 files changed, 39 insertions(+)
+
+diff --git a/v2xHostPal/v2xEvoBootGlobalCnf.mk b/v2xHostPal/v2xEvoBootGlobalCnf.mk
+index 8603bcd..407595e 100755
+--- a/v2xHostPal/v2xEvoBootGlobalCnf.mk
++++ b/v2xHostPal/v2xEvoBootGlobalCnf.mk
+@@ -25,6 +25,7 @@ REMOTE=3
+ IMX8=4
+ COMPANION=5
+ SYSVAL_BOOTSTATUS_BASED=6
++SRIMX8DXLSOM=9
+ #list of OS supported
+ LINUX=1
+ QNX=2
+@@ -111,6 +112,17 @@ PAL_SDIO_ENABLE=0
+ PAL_GPIO_ENABLE=0
+ endif
+ 
++ifeq ($(findstring srimx8dxlsom,$(V2X_TARGET)), srimx8dxlsom)
++PLATFORM_OS = linux
++CC ?= gcc -fno-exceptions
++GLOBAL_CFLAGS += -DV2X_BOARD=$(SRIMX8DXLSOM) -DV2X_OS=$(LINUX) -O2
++PAL_SDIO_ENABLE=1
++PAL_SPI_ENABLE=0
++PAL_UART_ENABLE=0
++PAL_ETHERNET_ENABLE=0
++PAL_GPIO_ENABLE=1
++endif
++
+ #to ENABLE-1 DISABLE-0 the respective interfaces in v2xHostBootIntf_init
+ PAL_SDIO_ENABLE?=1
+ PAL_SPI_ENABLE?=1
+diff --git a/v2xHostPal/v2xHostDal/inc/v2xHostDalBoot.h b/v2xHostPal/v2xHostDal/inc/v2xHostDalBoot.h
+index ead6216..c5747cd 100755
+--- a/v2xHostPal/v2xHostDal/inc/v2xHostDalBoot.h
++++ b/v2xHostPal/v2xHostDal/inc/v2xHostDalBoot.h
+@@ -177,6 +177,28 @@ retain, install, activate or otherwise use the software.
+ #define V2XHOSTBOOT_SAF2_SDIO_FLOW_CNTRL            0u
+ #define V2XHOSTBOOT_SAF2_SPI_UART_FLOW_CNTRL        0u
+ #define V2XHOSTBOOT_SAF2_ETH_FLOW_CNTRL             0u
++
++
++/* SolidRun i.MX8DXL SoM */
++#elif (V2X_BOARD == SRIMX8DXLSOM)
++#define V2XHOSTBOOT_MAX_SAF_SUPPORTED               1u
++#define V2XHOSTBOOT_GPIO_SAF1_BS1                   41u
++#define V2XHOSTBOOT_GPIO_SAF1_BS2                   32u
++#define V2XHOSTBOOT_GPIO_SAF1_BS3                   33u
++#define V2XHOSTBOOT_GPIO_SAF1_RST                   42u
++#define V2XHOSTBOOT_GPIO_SAF1_SUPPORTED             TRUE
++#define V2XHOSTBOOT_SAF1_SDIO_FLOW_CNTRL            (FLWCTRL_PBL_BOOTSTATUS | FLWCTRL_SBL_INT)
++#define V2XHOSTBOOT_SAF1_SPI_UART_FLOW_CNTRL        (FLWCTRL_PBL_BOOTSTATUS | FLWCTRL_SBL_BOOTSTATUS)
++#define V2XHOSTBOOT_SAF1_ETH_FLOW_CNTRL             (FLWCTRL_PBL_BOOTSTATUS | FLWCTRL_SBL_INT)
++
++#define V2XHOSTBOOT_GPIO_SAF2_BS1                   0u
++#define V2XHOSTBOOT_GPIO_SAF2_BS2                   0u
++#define V2XHOSTBOOT_GPIO_SAF2_BS3                   0u
++#define V2XHOSTBOOT_GPIO_SAF2_RST                   0u
++#define V2XHOSTBOOT_GPIO_SAF2_SUPPORTED             FALSE
++#define V2XHOSTBOOT_SAF2_SDIO_FLOW_CNTRL            (FLWCTRL_PBL_BOOTSTATUS | FLWCTRL_SBL_INT)
++#define V2XHOSTBOOT_SAF2_SPI_UART_FLOW_CNTRL        (FLWCTRL_PBL_BOOTSTATUS | FLWCTRL_SBL_BOOTSTATUS)
++#define V2XHOSTBOOT_SAF2_ETH_FLOW_CNTRL             (FLWCTRL_PBL_BOOTSTATUS | FLWCTRL_SBL_INT)
+ #endif
+ 
+ 
+diff --git a/v2xHostPal/v2xHostDal/inc/v2xHostDalCommonTypes.h b/v2xHostPal/v2xHostDal/inc/v2xHostDalCommonTypes.h
+index 818541e..0158ea3 100755
+--- a/v2xHostPal/v2xHostDal/inc/v2xHostDalCommonTypes.h
++++ b/v2xHostPal/v2xHostDal/inc/v2xHostDalCommonTypes.h
+@@ -52,6 +52,7 @@ retain, install, activate or otherwise use the software.
+ #define IMX8                                        4u
+ #define COMPANION                                   5u
+ #define SYSVAL_BOOTSTATUS_BASED                     6u
++#define SRIMX8DXLSOM                                9u
+ 
+ #if (V2X_OS==LINUX)
+ #ifndef LITTLE
+diff --git a/v2xHostPal/v2xHostDal/inc/v2xHostDalSdio.h b/v2xHostPal/v2xHostDal/inc/v2xHostDalSdio.h
+index 979f2f2..ec71a5a 100755
+--- a/v2xHostPal/v2xHostDal/inc/v2xHostDalSdio.h
++++ b/v2xHostPal/v2xHostDal/inc/v2xHostDalSdio.h
+@@ -50,6 +50,10 @@ retain, install, activate or otherwise use the software.
+ #define V2XHOSTDALSDIO_DTS_TARGET1            "/dev/saf_sdio1"
+ #define V2XHOSTDALSDIO_DTS_TARGET2            "/dev/saf_sdio2"
+ #define V2XHOSTDALSDIO_DEFAULT_CLK_MHZ        50000000
++#elif (V2X_BOARD == SRIMX8DXLSOM)
++#define V2XHOSTDALSDIO_DTS_TARGET1            "/dev/saf_sdio1"
++#define V2XHOSTDALSDIO_DTS_TARGET2            "/dev/null"
++#define V2XHOSTDALSDIO_DEFAULT_CLK_MHZ        40000000
+ #define V2XHOSTDALSDIO_MAX_SUPPORTED_CLK_MHZ  50
+ #endif
+ #define V2XHOSTDALSDIO_DTSCHECK_TIMEOUT       1000  //1sec
+-- 
+2.39.0
+

--- a/patches/safboot/0002-v2x-saf-boot-Install-lib-as-required-by-ldd.patch
+++ b/patches/safboot/0002-v2x-saf-boot-Install-lib-as-required-by-ldd.patch
@@ -1,0 +1,39 @@
+From 8e11af50d66f372fb3e1a2e06a6881f051e0ce23 Mon Sep 17 00:00:00 2001
+From: Jannik Beyerstedt <beyerstedt@consider-it.de>
+Date: Wed, 21 Dec 2022 15:02:11 +0100
+Subject: [PATCH 2/2] v2x-saf-boot: Install lib as required by ldd
+
+The v2x_saf_boot binary depends on the libraries ending in .so.3.5, but
+only .so and .so.3.5.0 are installed.
+---
+ v2xHostBootLib/Makefile | 1 +
+ v2xHostPal/Makefile     | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/v2xHostBootLib/Makefile b/v2xHostBootLib/Makefile
+index db010fa..a52a512 100755
+--- a/v2xHostBootLib/Makefile
++++ b/v2xHostBootLib/Makefile
+@@ -21,6 +21,7 @@ sharedLibBuild:
+ 	mkdir -p $(TARGET_FOLDER)
+ 	$(CC) $(EXTERNAL_LDFLAGS) -shared -Wl,-soname,lib$(BOOTTOOL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR) -o lib$(BOOTTOOL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR).$(V2X_CFG_REL_PATCH)  *.o 
+ 	cp lib$(BOOTTOOL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR).$(V2X_CFG_REL_PATCH)  $(TARGET_FOLDER)/lib$(BOOTTOOL_LIB).so
++	cp lib$(BOOTTOOL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR).$(V2X_CFG_REL_PATCH)  $(TARGET_FOLDER)/lib$(BOOTTOOL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR)
+ 	mv lib$(BOOTTOOL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR).$(V2X_CFG_REL_PATCH)  $(TARGET_FOLDER)/lib$(BOOTTOOL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR).$(V2X_CFG_REL_PATCH)
+ 		
+ clean:
+diff --git a/v2xHostPal/Makefile b/v2xHostPal/Makefile
+index 9ffd858..4a2c317 100755
+--- a/v2xHostPal/Makefile
++++ b/v2xHostPal/Makefile
+@@ -33,6 +33,7 @@ sharedLibBuild:
+ 	mkdir -p $(TARGET_FOLDER)	
+ 	$(CC) $(EXTERNAL_LDFLAGS) -shared -Wl,-soname,lib$(PAL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR) -o lib$(PAL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR).$(V2X_CFG_REL_PATCH) *.o 
+ 	cp lib$(PAL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR).$(V2X_CFG_REL_PATCH) $(TARGET_FOLDER)/lib$(PAL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR).$(V2X_CFG_REL_PATCH)
++	cp lib$(PAL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR).$(V2X_CFG_REL_PATCH) $(TARGET_FOLDER)/lib$(PAL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR)
+ 	mv lib$(PAL_LIB).so.$(V2X_CFG_REL_MAJOR).$(V2X_CFG_REL_MINOR).$(V2X_CFG_REL_PATCH) $(TARGET_FOLDER)/lib$(PAL_LIB).so
+ 	
+ 
+-- 
+2.39.0
+

--- a/patches/safsdio/0001-saf-sdio-Change-if-KERNEL-to-ifdef.patch
+++ b/patches/safsdio/0001-saf-sdio-Change-if-KERNEL-to-ifdef.patch
@@ -1,0 +1,25 @@
+From f67f42e486f4ca0503cdfe26dfa00bd3ee9a1db9 Mon Sep 17 00:00:00 2001
+From: Jannik Beyerstedt <beyerstedt@consider-it.de>
+Date: Tue, 20 Dec 2022 19:05:51 +0100
+Subject: [PATCH] saf-sdio: Change #if KERNEL to #ifdef
+
+---
+ include/saf_sdio.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/saf_sdio.h b/include/saf_sdio.h
+index 1085e2c..265d05f 100644
+--- a/include/saf_sdio.h
++++ b/include/saf_sdio.h
+@@ -37,7 +37,7 @@
+ #ifndef SAF_SDIO_H
+ #define SAF_SDIO_H
+ 
+-#if __KERNEL__
++#ifdef __KERNEL__
+ 
+ #include <linux/cdev.h>
+ #include <linux/atomic.h>
+-- 
+2.39.0
+

--- a/runme.sh
+++ b/runme.sh
@@ -350,8 +350,9 @@ fi;
 # Prepare final rootfs
 cp rootfs.e2.orig rootfs.e2
 
-# Add kernel to rootfs
-find "${ROOTDIR}/images/linux" -type f -printf "%P\n" | e2cp -G 0 -O 0 -P 644 -s "${ROOTDIR}/images/linux" -d "${ROOTDIR}/build/debian/rootfs.e2:" -a
+# Add kernel and cross-compiled tools to rootfs
+find "${ROOTDIR}/images/linux" -type f -printf "%P\n" | e2cp -G 0 -O 0 -p -s "${ROOTDIR}/images/linux" -d "${ROOTDIR}/build/debian/rootfs.e2:" -a
+find "${ROOTDIR}/images/linux" -type l -printf "%P\n" | e2cp -G 0 -O 0 -p -s "${ROOTDIR}/images/linux" -d "${ROOTDIR}/build/debian/rootfs.e2:" -a
 
 # Add overlay to rootfs
 find "${ROOTDIR}/overlay" -type f -printf "%P\n" | e2cp -G 0 -O 0 -s "${ROOTDIR}/overlay" -d "${ROOTDIR}/build/debian/rootfs.e2:" -a

--- a/runme.sh
+++ b/runme.sh
@@ -3,7 +3,7 @@
 ### Options
 : ${CROSS_COMPILE:=aarch64-linux-gnu-}
 : ${SOC_REVISION:=A0}
-: ${IMAGE_SIZE_MiB:=1000}
+: ${IMAGE_SIZE_MiB:=1300}
 
 ### Versions
 ATF_GIT_URI=https://github.com/nxp-imx/imx-atf
@@ -279,7 +279,7 @@ if [ ! -f rootfs.e2.orig ] || [[ ${ROOTDIR}/${BASH_SOURCE[0]} -nt rootfs.e2.orig
 	fakeroot debootstrap --variant=minbase \
 		--arch=arm64 --components=main,contrib,non-free \
 		--foreign \
-		--include=apt-transport-https,bluez,busybox,ca-certificates,can-utils,command-not-found,curl,e2fsprogs,ethtool,fdisk,gpiod,gpsd,gpsd-tools,haveged,i2c-tools,ifupdown,iputils-ping,isc-dhcp-client,iw,initramfs-tools,libpcap0.8,locales,nano,net-tools,ntpdate,openssh-server,psmisc,python3-gps,python3-serial,rfkill,sudo,systemd-sysv,systemd-timesyncd,tio,usbutils,wget,wpasupplicant,xterm \
+		--include=apt-transport-https,bluez,busybox,ca-certificates,can-utils,command-not-found,curl,e2fsprogs,ethtool,fdisk,gpiod,gpsd,gpsd-tools,gpsd-clients,haveged,i2c-tools,ifupdown,iputils-ping,isc-dhcp-client,iw,initramfs-tools,libpcap0.8,locales,nano,net-tools,ntpdate,openssh-server,psmisc,python3-gps,python3-serial,rfkill,sudo,systemd-sysv,systemd-timesyncd,tio,usbutils,wget,wpasupplicant,xterm \
 		bullseye \
 		stage1 \
 		https://deb.debian.org/debian


### PR DESCRIPTION
To properly boot the SAF5400 and communicate with it, some more things are needed besides the kernel module. So this PR cross-compiles and installs them. Some additional patches to the source are needed though.

Open questions:
- Shouldn't out-of-tree kernel modules be installed in the `extra` directory?
- Is there a way to preserve the symlinks of versioned shared libraries when adding them to the image with `e2cp`?