### PR TITLE
chrony: Fix startup order

### DIFF
--- a/overlay/etc/systemd/system/chrony.service.d/pps0-dependency.conf
+++ b/overlay/etc/systemd/system/chrony.service.d/pps0-dependency.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=dev-pps0.device
+Wants=dev-pps0.device

--- a/overlay/etc/udev/rules.d/gnss.rules
+++ b/overlay/etc/udev/rules.d/gnss.rules
@@ -2,4 +2,4 @@
 SUBSYSTEM=="gnss", GROUP="dialout"
 
 # restart chrony as pps device changes
-SUBSYSTEM=="pps", KERNEL=="pps0", RUN+="/usr/bin/systemctl --no-block restart chrony.service"
+SUBSYSTEM=="pps", KERNEL=="pps0", RUN+="/usr/bin/systemctl --no-block restart chrony.service", TAG+="systemd"


### PR DESCRIPTION
chrony.service was started before /dev/pps0 exists and therefore failed multiple times. This can be prevented by letting udev create a systemd device entry and letting chrony.service depend on it.