### PR TITLE
Store (automatic) version number in the image

### DIFF
--- a/runme.sh
+++ b/runme.sh
@@ -301,6 +301,12 @@ fi
 # regenerate modules dependencies
 depmod -b "${ROOTDIR}/images/linux/usr" -F "${ROOTDIR}/build/linux-build/System.map" ${KRELEASE}
 
+# Generate firmware image version identifier
+install -v -d "${ROOTDIR}/images/linux/opt"
+echo "SOC_REVISION: ${SOC_REVISION}" > "${ROOTDIR}/images/linux/opt/image-revision.txt"
+echo "GATEWAY_REVISION: ${GATEWAY_REVISION}" >> "${ROOTDIR}/images/linux/opt/image-revision.txt"
+echo "GIT_VERSION: $(git describe --always)" >> "${ROOTDIR}/images/linux/opt/image-revision.txt"
+
 # Generate a Debian rootfs
 mkdir -p "${ROOTDIR}/build/debian"
 cd "${ROOTDIR}/build/debian"


### PR DESCRIPTION
I would like to have the version of the image build somewhere in the eMMC image as we will probably need to build different variants which will be tagged accordingly. I just don't know which directory would be the right place for something like this.

SoC and Gateway revision don't actually influence the eMMC image, but I added them for the sake of completeness.